### PR TITLE
Move diamond-hand signing logic to lib

### DIFF
--- a/app/api/attest/route.ts
+++ b/app/api/attest/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { isDiamondHands, hasDiamondHand } from "@/lib/diamond-hands"
+import { isDiamondHands, attestedDiamondHands } from "@/lib/diamond-hands"
 import { signDiamondHand } from '@/lib/signing/diamond-hand';
 
 import {
@@ -34,7 +34,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'User is not diamond hands' }, { status: 400 })
   }
 
-  if (await hasDiamondHand(walletAddress)) {
+  if (await attestedDiamondHands(walletAddress)) {
     return NextResponse.json({ error: 'User has attestation' }, { status: 400 })
   }
 

--- a/app/api/attest/route.ts
+++ b/app/api/attest/route.ts
@@ -1,14 +1,11 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { JsonRpcProvider, Wallet } from "ethers";
 import { auth } from "@/lib/auth";
-import { EIP712Proxy } from "@ethereum-attestation-service/eas-sdk/dist/eip712-proxy";
-import { isDiamondHands } from "@/lib/diamond-hands"
-import { jsonStringifyBigInt } from "@/lib/utils"
+import { isDiamondHands, hasDiamondHand } from "@/lib/diamond-hands"
+import { signDiamondHand } from '@/lib/signing/diamond-hand';
 
 import {
   PROXY_CONTRACT_ADDRESS,
   PRIVATE_KEY,
-  ATTESTATION_CONFIG,
 } from "@/lib/config"
 
 
@@ -37,36 +34,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'User is not diamond hands' }, { status: 400 })
   }
 
-  const provider = new JsonRpcProvider(process.env.RPC_PROVIDER)
-  const signer = new Wallet(PRIVATE_KEY, provider);
+  if (await hasDiamondHand(walletAddress)) {
+    return NextResponse.json({ error: 'User has attestation' }, { status: 400 })
+  }
 
-  const proxy = new EIP712Proxy(PROXY_CONTRACT_ADDRESS, { signer: signer })
-
-  const delegated = await proxy.getDelegated()
-
-  const attestationType = ATTESTATION_CONFIG['diamond-hand'];
-
-  const params = {
-    schema: attestationType.schemaUID,
-    recipient: walletAddress,
-    expirationTime: 0n,
-    revocable: false,
-    refUID: '0x0000000000000000000000000000000000000000000000000000000000000000',
-    data: attestationType.encoder.encodeData([{
-      name: 'hasDiamondHand',
-      type: 'bool',
-      value: true
-    }]),
-    value: 0n,
-    deadline: 0n
-  };
-
-  const response = await delegated.signDelegatedProxyAttestation(params, signer);
-  const signedResponse = jsonStringifyBigInt({
-    message: response.message,
-    signature: response.signature,
-  })
-
-
+  const signedResponse = await signDiamondHand(walletAddress);
   return NextResponse.json({ signedResponse })
 }

--- a/hooks/useIsAttested.ts
+++ b/hooks/useIsAttested.ts
@@ -3,61 +3,23 @@ import { usePublicClient } from 'wagmi'
 
 import { PROXY_CONTRACT_ADDRESS } from "@/lib/config"
 import { useEffect, useState } from 'react';
+import proxyABI from '@/lib/proxy-abi.json';
 
-const abi = [
-  {
-    type: "function",
-    name: "userAuthenticationCount",
-    inputs: [
-      { name: "user", type: "address", internalType: "address" },
-      { name: "id", type: "string", internalType: "string" }
-    ],
-    outputs: [
-      { name: "", type: "uint256", internalType: "uint256" }
-    ],
-    stateMutability: "view"
-  },
-  {
-    type: "function",
-    name: "userAuthentication",
-    inputs: [
-      { name: "user", type: "address", internalType: "address" },
-      { name: "id", type: "string", internalType: "string" },
-      { name: "idx", type: "uint256", internalType: "uint256" }
-    ],
-    outputs: [
-      { name: "", type: "bytes32", internalType: "bytes32" }
-    ],
-    stateMutability: "view"
-  }
-] as const
 
-async function check(client: PublicClient, address: Address) {
+async function check(client: PublicClient, address: Address, attestationType: string) {
   const attestationCount = await client.readContract({
     address: PROXY_CONTRACT_ADDRESS,
-    abi: abi,
+    abi: proxyABI,
     functionName: 'userAuthenticationCount',
-    args: [address, 'diamond-hand'],
+    args: [address, attestationType],
   })
-
   if (!attestationCount) {
     return false;
-  }
-
-  const attestationIds = [];
-  for (let i = 0; i < attestationCount; i++) {
-    const attestationId = await client.readContract({
-      address: PROXY_CONTRACT_ADDRESS,
-      abi: abi,
-      functionName: 'userAuthentication',
-      args: [address, 'diamond-hand', BigInt(i)],
-    });
-    attestationIds.push(attestationId);
   }
   return true;
 }
 
-export function useIsAttested(address: Address) {
+export function useIsAttested(address: Address, attestationType: string) {
   const client = usePublicClient();
   const [isAttested, setIsAttested] = useState(false);
 
@@ -66,7 +28,7 @@ export function useIsAttested(address: Address) {
       return;
     }
 
-    const promise = check(client, address);
+    const promise = check(client, address, attestationType);
 
     promise.then((isAttested) => {
       setIsAttested(isAttested);

--- a/lib/diamond-hands.ts
+++ b/lib/diamond-hands.ts
@@ -1,4 +1,7 @@
 import type { Address } from 'viem'
+import { getProxy } from "@/lib/proxy";
+import { JsonRpcProvider, Wallet } from "ethers";
+
 
 import prodDiamondHands from './diamond-hands-data.json'
 const devDiamondHands: Address[] = [
@@ -10,4 +13,10 @@ const diamondHands = new Set(process.env.NODE_ENV === 'production' ? prodDiamond
 
 export function isDiamondHands(address: Address) {
   return diamondHands.has(address.toLowerCase())
+}
+
+export async function hasDiamondHand(address: Address) {
+  const provider = new JsonRpcProvider(process.env.RPC_PROVIDER)
+  const proxy = getProxy(undefined, provider);
+  return (await proxy.userAuthenticationCount(address, 'diamond-hand')) >= 1;
 }

--- a/lib/diamond-hands.ts
+++ b/lib/diamond-hands.ts
@@ -15,8 +15,8 @@ export function isDiamondHands(address: Address) {
   return diamondHands.has(address.toLowerCase())
 }
 
-export async function hasDiamondHand(address: Address) {
+export async function attestedDiamondHands(address: Address) {
   const provider = new JsonRpcProvider(process.env.RPC_PROVIDER)
-  const proxy = getProxy(undefined, provider);
+  const proxy = getProxy(provider);
   return (await proxy.userAuthenticationCount(address, 'diamond-hand')) >= 1;
 }

--- a/lib/proxy-abi.json
+++ b/lib/proxy-abi.json
@@ -1,0 +1,1163 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "eas",
+        "type": "address",
+        "internalType": "contract IEAS"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "_attester",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "addAttestationType",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "schemaId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "rewarder",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "attestByDelegation",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "delegatedRequest",
+        "type": "tuple",
+        "internalType": "struct DelegatedProxyAttestationRequest",
+        "components": [
+          {
+            "name": "schema",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "data",
+            "type": "tuple",
+            "internalType": "struct AttestationRequestData",
+            "components": [
+              {
+                "name": "recipient",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "expirationTime",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "revocable",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "refUID",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "data",
+                "type": "bytes",
+                "internalType": "bytes"
+              },
+              {
+                "name": "value",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "signature",
+            "type": "tuple",
+            "internalType": "struct Signature",
+            "components": [
+              {
+                "name": "v",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "r",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "s",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              }
+            ]
+          },
+          {
+            "name": "attester",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "deadline",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "attestationTypes",
+    "inputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "schemaId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "rewarder",
+        "type": "address",
+        "internalType": "contract IRewarder"
+      },
+      {
+        "name": "enabled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "attester",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "eip712Domain",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "fields",
+        "type": "bytes1",
+        "internalType": "bytes1"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "version",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "chainId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "verifyingContract",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "extensions",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAttestTypeHash",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getAttester",
+    "inputs": [
+      {
+        "name": "uid",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDomainSeparator",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getEAS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IEAS"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getName",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRevokeTypeHash",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "multiAttestByDelegation",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "multiDelegatedRequests",
+        "type": "tuple[]",
+        "internalType": "struct MultiDelegatedProxyAttestationRequest[]",
+        "components": [
+          {
+            "name": "schema",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "data",
+            "type": "tuple[]",
+            "internalType": "struct AttestationRequestData[]",
+            "components": [
+              {
+                "name": "recipient",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "expirationTime",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "revocable",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "refUID",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "data",
+                "type": "bytes",
+                "internalType": "bytes"
+              },
+              {
+                "name": "value",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "signatures",
+            "type": "tuple[]",
+            "internalType": "struct Signature[]",
+            "components": [
+              {
+                "name": "v",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "r",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "s",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              }
+            ]
+          },
+          {
+            "name": "attester",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "deadline",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "multiAttestByDelegation",
+    "inputs": [
+      {
+        "name": "multiDelegatedRequests",
+        "type": "tuple[]",
+        "internalType": "struct MultiDelegatedProxyAttestationRequest[]",
+        "components": [
+          {
+            "name": "schema",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "data",
+            "type": "tuple[]",
+            "internalType": "struct AttestationRequestData[]",
+            "components": [
+              {
+                "name": "recipient",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "expirationTime",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "revocable",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "refUID",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "data",
+                "type": "bytes",
+                "internalType": "bytes"
+              },
+              {
+                "name": "value",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "signatures",
+            "type": "tuple[]",
+            "internalType": "struct Signature[]",
+            "components": [
+              {
+                "name": "v",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "r",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "s",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              }
+            ]
+          },
+          {
+            "name": "attester",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "deadline",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "multiRevokeByDelegation",
+    "inputs": [
+      {
+        "name": "multiDelegatedRequests",
+        "type": "tuple[]",
+        "internalType": "struct MultiDelegatedProxyRevocationRequest[]",
+        "components": [
+          {
+            "name": "schema",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "data",
+            "type": "tuple[]",
+            "internalType": "struct RevocationRequestData[]",
+            "components": [
+              {
+                "name": "uid",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "value",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "signatures",
+            "type": "tuple[]",
+            "internalType": "struct Signature[]",
+            "components": [
+              {
+                "name": "v",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "r",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "s",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              }
+            ]
+          },
+          {
+            "name": "revoker",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "deadline",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "multiRevokeByDelegation",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "multiDelegatedRequests",
+        "type": "tuple[]",
+        "internalType": "struct MultiDelegatedProxyRevocationRequest[]",
+        "components": [
+          {
+            "name": "schema",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "data",
+            "type": "tuple[]",
+            "internalType": "struct RevocationRequestData[]",
+            "components": [
+              {
+                "name": "uid",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "value",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "signatures",
+            "type": "tuple[]",
+            "internalType": "struct Signature[]",
+            "components": [
+              {
+                "name": "v",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "r",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "s",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              }
+            ]
+          },
+          {
+            "name": "revoker",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "deadline",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "revokeByDelegation",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "delegatedRequest",
+        "type": "tuple",
+        "internalType": "struct DelegatedProxyRevocationRequest",
+        "components": [
+          {
+            "name": "schema",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "data",
+            "type": "tuple",
+            "internalType": "struct RevocationRequestData",
+            "components": [
+              {
+                "name": "uid",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "value",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "signature",
+            "type": "tuple",
+            "internalType": "struct Signature",
+            "components": [
+              {
+                "name": "v",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "r",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "s",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              }
+            ]
+          },
+          {
+            "name": "revoker",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "deadline",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "revokeByDelegation",
+    "inputs": [
+      {
+        "name": "delegatedRequest",
+        "type": "tuple",
+        "internalType": "struct DelegatedProxyRevocationRequest",
+        "components": [
+          {
+            "name": "schema",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "data",
+            "type": "tuple",
+            "internalType": "struct RevocationRequestData",
+            "components": [
+              {
+                "name": "uid",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "value",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "signature",
+            "type": "tuple",
+            "internalType": "struct Signature",
+            "components": [
+              {
+                "name": "v",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "r",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "s",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              }
+            ]
+          },
+          {
+            "name": "revoker",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "deadline",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "rewardToken",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract DiamondToken"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateAttestationTypeRewarder",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "rewarder",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateAttestationTypeStatus",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "enabled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateAttester",
+    "inputs": [
+      {
+        "name": "_attester",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "userAttestations",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "userAuthentication",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "attestationType",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "userAuthenticationCount",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "attestationType",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "version",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "AttestationTypeAdded",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "string",
+        "indexed": true,
+        "internalType": "string"
+      },
+      {
+        "name": "schemaId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "rewarder",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AttestationTypeRewarderUpdated",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "string",
+        "indexed": true,
+        "internalType": "string"
+      },
+      {
+        "name": "rewarder",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AttestationTypeStatusUpdated",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "string",
+        "indexed": true,
+        "internalType": "string"
+      },
+      {
+        "name": "enabled",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AttesterUpdated",
+    "inputs": [
+      {
+        "name": "attester",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "EIP712DomainChanged",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AccessDenied",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AttestationTypeDoesNotExist",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AttestationTypeExists",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "DeadlineExpired",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Disabled",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "DisabledAttestationType",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidEAS",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidLength",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidSchemaId",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidShortString",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidSignature",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotFound",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "StringTooLong",
+    "inputs": [
+      {
+        "name": "str",
+        "type": "string",
+        "internalType": "string"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UsedSignature",
+    "inputs": []
+  }
+]

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -1,10 +1,24 @@
 import { ethers } from 'ethers';
+import proxyABI from './proxy-abi.json';
 
 
-export function getProxy(signer: ethers.JsonRpcSigner) {
-  return new ethers.Contract(
-    process.env.NEXT_PUBLIC_PROXY_CONTRACT_ADDRESS!,
-    ["function attestByDelegation(string id, (bytes32 schema, (address recipient, uint64 expirationTime, bool revocable, bytes32 refUID, bytes data, uint256 value) data, (uint8 v, bytes32 r, bytes32 s) signature, address attester, uint64 deadline) delegatedRequest)"],
-    signer
-  )
+export function getProxy(signer?: ethers.JsonRpcSigner, provider?: ethers.JsonRpcProvider) {
+  if (typeof(signer) === 'undefined' && typeof(provider) === 'undefined') {
+    return new ethers.Contract(
+      process.env.NEXT_PUBLIC_PROXY_CONTRACT_ADDRESS!,
+      proxyABI,
+    );
+  } else if (typeof(signer) !== 'undefined') {
+    return new ethers.Contract(
+      process.env.NEXT_PUBLIC_PROXY_CONTRACT_ADDRESS!,
+      proxyABI,
+      signer
+    )
+  } else {
+    return new ethers.Contract(
+      process.env.NEXT_PUBLIC_PROXY_CONTRACT_ADDRESS!,
+      proxyABI,
+      provider,
+    )
+  };
 }

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -2,23 +2,10 @@ import { ethers } from 'ethers';
 import proxyABI from './proxy-abi.json';
 
 
-export function getProxy(signer?: ethers.JsonRpcSigner, provider?: ethers.JsonRpcProvider) {
-  if (typeof(signer) === 'undefined' && typeof(provider) === 'undefined') {
-    return new ethers.Contract(
-      process.env.NEXT_PUBLIC_PROXY_CONTRACT_ADDRESS!,
-      proxyABI,
-    );
-  } else if (typeof(signer) !== 'undefined') {
-    return new ethers.Contract(
-      process.env.NEXT_PUBLIC_PROXY_CONTRACT_ADDRESS!,
-      proxyABI,
-      signer
-    )
-  } else {
-    return new ethers.Contract(
-      process.env.NEXT_PUBLIC_PROXY_CONTRACT_ADDRESS!,
-      proxyABI,
-      provider,
-    )
-  };
+export function getProxy(signerOrProvider: ethers.JsonRpcSigner | ethers.JsonRpcProvider) {
+  return new ethers.Contract(
+    process.env.NEXT_PUBLIC_PROXY_CONTRACT_ADDRESS!,
+    proxyABI,
+    signerOrProvider
+  );
 }

--- a/lib/signing/diamond-hand.ts
+++ b/lib/signing/diamond-hand.ts
@@ -1,0 +1,44 @@
+'use server';
+
+import type { Address } from 'viem';
+import { JsonRpcProvider, Wallet } from "ethers";
+import { EIP712Proxy } from "@ethereum-attestation-service/eas-sdk/dist/eip712-proxy";
+import {
+  PROXY_CONTRACT_ADDRESS,
+  PRIVATE_KEY,
+  ATTESTATION_CONFIG,
+} from "@/lib/config"
+import { jsonStringifyBigInt } from "@/lib/utils"
+
+
+export async function signDiamondHand(address: Address) {
+  const provider = new JsonRpcProvider(process.env.RPC_PROVIDER)
+  const signer = new Wallet(PRIVATE_KEY, provider);
+  const proxy = new EIP712Proxy(PROXY_CONTRACT_ADDRESS, { signer: signer })
+
+  const delegated = await proxy.getDelegated()
+
+  const attestationType = ATTESTATION_CONFIG['diamond-hand'];
+
+  const params = {
+    schema: attestationType.schemaUID,
+    recipient: address,
+    expirationTime: 0n,
+    revocable: false,
+    refUID: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    data: attestationType.encoder.encodeData([{
+      name: 'hasDiamondHand',
+      type: 'bool',
+      value: true
+    }]),
+    value: 0n,
+    deadline: 0n
+  };
+
+  const response = await delegated.signDelegatedProxyAttestation(params, signer);
+  return jsonStringifyBigInt({
+    message: response.message,
+    signature: response.signature,
+  })
+
+}


### PR DESCRIPTION
Move the signing logic for diamond-hand out of the `POST` handler. This is the start of making the application work with multiple attestation types that will have different logic when determining whether to sign a request or not.