### PR TITLE
Remove in-memory cache for storing JWT signing key

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -2,11 +2,6 @@ import { SchemaEncoder } from "@ethereum-attestation-service/eas-sdk";
 import type { Address } from 'viem'
 import { Chain as ViemChain, avalanche, avalancheFuji, hardhat } from 'viem/chains';
 
-export const redisConf = {
-  url: process.env.REDIS_URL,
-  token: process.env.REDIS_TOKEN,
-}
-
 export const ATTESTATION_DEADLINE = 60 * 5;
 
 const prodChains = [avalanche] as ViemChain[]

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,8 +1,7 @@
 import { Redis } from "@upstash/redis";
-import { redisConf } from "@/lib/config";
 
 
-export function getRedisInstance(config = redisConf) {
+export function getRedisInstance() {
   try {
     return Redis.fromEnv();
   } catch (e) {


### PR DESCRIPTION
The JWT signing key is derived from `JWT_SECRET` and passed to our code by next-auth in the `encode` and `decode` callbacks.

In order to make the secret available to other callbacks, I was wrongly storing it in a memory cache, which simply doesn't work in serveless deployments like vercel.

Switch to using redis as the cache.